### PR TITLE
Show board view immediately on load

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -536,6 +536,8 @@
       if(this._initialized) return;
       this._initialized=true;
       this.cache(); this.bind(); this.renderLobbyPlayers(2);
+      this.bootstrapBoard();
+      this.toGame();
       if(localStorage.getItem('ac_save_v1')) this.$.btnContinue.disabled=false;
       this.autoLaunch();
     },


### PR DESCRIPTION
## Summary
- pre-render the board during initialization so the map is ready immediately
- switch to the game view on startup to display the board by default

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e18bbec7308321be102f99615d6f5d