### PR TITLE
Add special tile effects and visuals to flight chess prototype

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -284,7 +284,26 @@
       track: { length: 52, orderClockwise: ["red","blue","yellow","green"], startIndex: { red:0, blue:13, yellow:26, green:39 } },
       homeLane: { length: 6, entryIndex: { red:50, blue:11, yellow:24, green:37 } },
       special: {
-        safeTiles: { start:true, extra:[] },
+        safeTiles: {
+          start:true,
+          extra:[3,16,29,42]
+        },
+        powerTiles:[
+          {idx:5,effect:'extra-roll',label:'🎲'},
+          {idx:18,effect:'advance-2',label:'+2'},
+          {idx:31,effect:'command-other',label:'⇄'},
+          {idx:44,effect:'advance-2',label:'+2'}
+        ],
+        trapTiles:[
+          {idx:12,effect:'skip-turn',label:'⚠'},
+          {idx:35,effect:'skip-turn',label:'⚠'}
+        ],
+        portals:[
+          {label:'A',from:7,to:28},
+          {label:'A',from:28,to:7},
+          {label:'B',from:21,to:46},
+          {label:'B',from:46,to:21}
+        ],
         ownColorJump: {
           enabled:true, steps:4,
           indices:{
@@ -308,7 +327,7 @@
       takeoff:"six", extraTurnOnSix:true, tripleSixPenalty:false,
       captureOnLand:true, stackEnabled:true, stackMovesTogether:false, blockadePassThrough:false,
       ownColorJump:{enabled:true,steps:4}, dashedFlight:{enabled:true,captureOnLanding:true},
-      homeLaneExactEntry:true, finishExact:"exact", safeTiles:{start:true,list:[]},
+      homeLaneExactEntry:true, finishExact:"exact", safeTiles:{start:true,list:[3,16,29,42]},
       turnTimerSec:0, animSpeed:'normal', undoEnabled:true,
     };
 
@@ -477,6 +496,21 @@
         const to = flightTo(player.color,current.idx);
         if(to!=null){ current=Pos.track(to); events.push({type:'flight',from:pos.idx,to}); viaFlight=true; }
       }
+      const portalLookup=new Map((BOARD.special.portals||[]).map(p=>[p.from,p]));
+      const visitedPortals=new Set();
+      while(current.kind==='track'){
+        const portal = portalLookup.get(current.idx);
+        if(!portal || visitedPortals.has(current.idx)) break;
+        visitedPortals.add(current.idx);
+        current=Pos.track(portal.to);
+        events.push({type:'portal',label:portal.label,from:portal.from,to:portal.to});
+      }
+      if(current.kind==='track'){
+        const power = (BOARD.special.powerTiles||[]).find(p=>p.idx===current.idx);
+        if(power) events.push({type:'power-up',effect:power.effect,label:power.label,idx:power.idx});
+        const trap = (BOARD.special.trapTiles||[]).find(t=>t.idx===current.idx);
+        if(trap) events.push({type:'trap',effect:trap.effect,label:trap.label,idx:trap.idx});
+      }
       return {final:current,events,viaFlight};
     }
 
@@ -538,7 +572,7 @@
     });
   })();
   const App = {
-    state:{ view:'lobby', players:[], rules:null, pieces:{}, turn:null, dice:null, history:[], settings:{keyboardMode:'shared'}, animating:false, consecutiveSixes:{}, turnTimerId:null, turnTimerRemaining:0, controlById:{}, inputLockUntil:0 },
+    state:{ view:'lobby', players:[], rules:null, pieces:{}, turn:null, dice:null, history:[], settings:{keyboardMode:'shared'}, animating:false, consecutiveSixes:{}, turnTimerId:null, turnTimerRemaining:0, controlById:{}, inputLockUntil:0, bonusSelecting:false, pendingBonus:null, skipTurns:{} },
     geom:{ track:[], home:{}, bases:{} },
     init(){
       if(this._initialized) return;
@@ -636,7 +670,7 @@
         return;
       }
       const control=this.currentControlModeForTurn();
-      const stage=(this.state.dice==null)?'roll':'move';
+      const stage=this.state.bonusSelecting?'bonus':(this.state.dice==null?'roll':'move');
       const list=document.createElement('ul');
       const title=document.createElement('h3');
       title.textContent=`${player.name} 的操作提示`;
@@ -646,15 +680,23 @@
       const playerIndex=this.state.players.findIndex(p=>p.id===player.id);
       if(control==='keyboard'){
         if(stage==='roll') hints.push('按 Space 擲骰 🎲');
-        if(mode==='shared' || mode==='custom'){ hints.push('用 1–4 選棋'); }
-        else if(mode==='dual'){
-          if(playerIndex===0) hints.push('P1：用 1–4 選棋');
-          else if(playerIndex===1) hints.push('P2：用 7–0 選棋');
-          else hints.push('自選鍵盤：用 1–4 選棋');
+        if(stage==='move' || stage==='bonus'){
+          if(mode==='shared' || mode==='custom'){ hints.push('用 1–4 選棋'); }
+          else if(mode==='dual'){
+            if(playerIndex===0) hints.push('P1：用 1–4 選棋');
+            else if(playerIndex===1) hints.push('P2：用 7–0 選棋');
+            else hints.push('自選鍵盤：用 1–4 選棋');
+          }
         }
         if(stage==='move'){
           if(moveCount>0) hints.push('選擇數字鍵執行移動');
           else hints.push('沒有可移動棋子，等待換手');
+        }
+        if(stage==='bonus'){
+          const desc=this.state.pendingBonus?.description||'使用增益移動';
+          hints.push(desc);
+          if(moveCount>0) hints.push('選擇符合條件的棋子以完成增益');
+          else hints.push('沒有可用的增益移動，稍後自動結束');
         }
         if(this.state.rules?.undoEnabled) hints.push('按 U 撤銷 (Undo)');
       }else{
@@ -662,6 +704,12 @@
         if(stage==='move'){
           if(moveCount>0) hints.push('點擊棋子或右側按鈕移動');
           else hints.push('目前沒有可行動的棋子');
+        }
+        if(stage==='bonus'){
+          const desc=this.state.pendingBonus?.description||'執行增益移動';
+          hints.push(desc);
+          if(moveCount>0) hints.push('點擊符合條件的棋子完成增益');
+          else hints.push('增益沒有可移動的棋子，稍後會自動略過');
         }
         if(this.state.rules?.undoEnabled) hints.push('如需撤銷，可點 Undo 按鈕');
       }
@@ -677,10 +725,11 @@
       const player=this.currentPlayer();
       if(!player) return '';
       const control=this.currentControlModeForTurn();
-      const stage=(this.state.dice==null)?'roll':'move';
+      const stage=this.state.bonusSelecting?'bonus':(this.state.dice==null?'roll':'move');
       let action='準備中';
       if(stage==='roll') action = control==='keyboard' ? '按 Space 擲骰 🎲' : '點擊 🎲 擲骰';
       else if(stage==='move') action = control==='keyboard' ? '用數字鍵選棋' : '點擊棋子行動';
+      else if(stage==='bonus') action = control==='keyboard' ? '用數字鍵觸發增益' : '選擇棋子完成增益';
       else action='等待下一步';
       return `${player.name} 的回合 — ${action}`;
     },
@@ -701,7 +750,7 @@
     },
     updateTurnPrompt(force=false){
       const msg=this.buildTurnPrompt();
-      const stage=(this.state.dice==null)?'roll':'move';
+      const stage=this.state.bonusSelecting?'bonus':(this.state.dice==null?'roll':'move');
       const lock=force && stage==='roll'?320:0;
       if(msg) this.showTurnPrompt(msg,{force,duration:2200,lock});
       else this.showTurnPrompt('',{force:true});
@@ -777,6 +826,14 @@
         const snapshot={players:this.state.players,pieces:this.state.pieces,turn:this.state.turn};
         this.state.legalMoves=window.GameRules.generateLegalMoves(snapshot,this.state.rules,this.state.dice);
       }
+      if(this.state.bonusSelecting && this.state.pendingBonus && Array.isArray(this.state.legalMoves)){
+        const pb=this.state.pendingBonus;
+        this.state.legalMoves=this.state.legalMoves.filter(m=>{
+          if(pb.restrict==='same') return m.pieceIndex===pb.pieceIndex;
+          if(pb.restrict==='others') return m.pieceIndex!==pb.pieceIndex;
+          return true;
+        });
+      }
       this.highlightMovables();
     },
     handleNoMoves(player){
@@ -827,6 +884,15 @@
       if(name==='classic') this.state.rules = cloneRules();
       else if(name==='fast') this.state.rules = cloneRules({takeoff:'fiveOrSix'});
       else this.state.rules = cloneRules();
+      this.applyBoardDefaultsToRules();
+    },
+    applyBoardDefaultsToRules(){
+      if(!this.state.rules) return;
+      const extras=window.GameRules.BOARD.special?.safeTiles?.extra||[];
+      const safeRaw=this.state.rules.safeTiles||{};
+      const merged=new Set([...(safeRaw.list||[]), ...extras]);
+      const safe={ start:(safeRaw.start!==false), list:Array.from(merged).sort((a,b)=>a-b) };
+      this.state.rules.safeTiles=safe;
     },
     readRulesFromForm(){
       const f=this.$.formSetup; const chk=n=>!!f.querySelector(`[name="${n}"]`)?.checked; const val=n=>f.querySelector(`[name="${n}"]:checked`)?.value; const num=(n,d)=>{const x=parseInt(f.querySelector(`[name="${n}"]`)?.value??d,10); return isNaN(x)?d:x;};
@@ -875,14 +941,18 @@
       if(players.length<2){ this.log('至少需要 2 位玩家'); return; }
       this.state.players=players; this.normalizePlayerControls(); this.state.turn=players[0].id; this.state.history=[]; this.state.pieces={};
       this.state.consecutiveSixes={};
+      this.state.skipTurns={};
+      this.state.bonusSelecting=false;
+      this.state.pendingBonus=null;
       this.updateControlAssignments();
       const preset=(this.$.formSetup.querySelector('input[name="preset"]:checked')?.value)||'classic';
-      if(preset==='custom'){ this.state.rules = Object.assign({}, window.GameRules.DEFAULT_RULES, this.readRulesFromForm()); }
+      if(preset==='custom'){ this.state.rules = Object.assign({}, window.GameRules.DEFAULT_RULES, this.readRulesFromForm()); this.applyBoardDefaultsToRules(); }
       else { this.applyPreset(preset); }
       const pieceCount=window.GameRules.BOARD.bases.perPlayer||1;
       for(const p of players){
         this.state.pieces[p.id]=Array.from({length:pieceCount},(_,idx)=>({pos:window.GameRules.Pos.base(idx), baseSlot:idx}));
         this.state.consecutiveSixes[p.id]=0;
+        this.state.skipTurns[p.id]=0;
       }
       this.normalizePieces();
       this.state.legalMoves=[]; this.state.animating=false; this.state.dice=null;
@@ -910,9 +980,13 @@
       const pieceCount=window.GameRules.BOARD.bases.perPlayer||1;
       this.state.pieces={};
       this.state.consecutiveSixes={};
+      this.state.skipTurns={};
+      this.state.bonusSelecting=false;
+      this.state.pendingBonus=null;
       for(const p of this.state.players){
         this.state.pieces[p.id]=Array.from({length:pieceCount},(_,idx)=>({pos:window.GameRules.Pos.base(idx), baseSlot:idx}));
         this.state.consecutiveSixes[p.id]=0;
+        this.state.skipTurns[p.id]=0;
       }
       this.normalizePieces();
       this.state.turn=this.state.players[0].id;
@@ -943,6 +1017,7 @@
       if(this.state.view!=='game'){ return; }
       if(!this.isInteractionPermitted(source)){ this.handleBlockedInteraction(source); return; }
       if(this.state.animating){ this.log('動畫進行中，稍候再擲'); return; }
+      if(this.state.bonusSelecting){ this.showToast('先完成增益移動',1200); return; }
       if(this.state.dice!=null){ this.log('本回合已擲骰'); return; }
       const player=this.currentPlayer();
       if(!player){ return; }
@@ -988,14 +1063,38 @@
       const svg=this.$.svg; const W=1000,H=1000; svg.setAttribute('viewBox',`0 0 ${W} ${H}`); const cx=W/2,cy=H/2,r=380;
       const gGrid=this.$.gGrid,gTiles=this.$.gTiles,gSpecials=this.$.gSpecials,gPieces=this.$.gPieces,gHL=this.$.gHL; gGrid.innerHTML=gTiles.innerHTML=gSpecials.innerHTML=gPieces.innerHTML=gHL.innerHTML='';
       const NS='http://www.w3.org/2000/svg'; const css=getComputedStyle(document.documentElement); const color=(name)=>css.getPropertyValue(name).trim();
-      const geom=this.geom={track:[],home:{},bases:{}};
+      const geom=this.geom={track:[],home:{},bases:{},runway:{}};
       const el=(n,a={},ch=[])=>{ const node=document.createElementNS(NS,n); for(const [k,v] of Object.entries(a)) node.setAttribute(k,v); ch.forEach(c=>node.appendChild(c)); return node; };
       const parseHex=(hex)=>{ const h=hex.replace('#',''); const parts=h.length===3?h.split('').map(c=>parseInt(c+c,16)):h.match(/.{2}/g).map(v=>parseInt(v,16)); return{r:parts[0],g:parts[1],b:parts[2]}; };
       const mixWithWhite=(hex,amount)=>{ const {r,g,b}=parseHex(hex); const mix=c=>Math.round(c+(255-c)*amount); return`rgb(${mix(r)},${mix(g)},${mix(b)})`; };
       const withAlpha=(hex,alpha)=>{ const {r,g,b}=parseHex(hex); return`rgba(${r},${g},${b},${alpha})`; };
       const ringPoint=(i,total=window.GameRules.BOARD.track.length)=>{ const a=(Math.PI*2)*(i/total)-Math.PI/2; const radius=r-20; return{ x:cx+Math.cos(a)*radius, y:cy+Math.sin(a)*radius, angle:a }; };
+      const starPoints=(cx,cy,outer,inner)=>{
+        const pts=[];
+        for(let i=0;i<10;i++){
+          const angle=(Math.PI/2)+(i*Math.PI/5);
+          const radius=(i%2===0)?outer:inner;
+          const px=cx+Math.cos(angle)*radius;
+          const py=cy-Math.sin(angle)*radius;
+          pts.push(`${px},${py}`);
+        }
+        return pts.join(' ');
+      };
       gGrid.appendChild(el('circle',{cx,cy,r:r+60,fill:'#0a0a0a',stroke:color('--tile-grid'),'stroke-width':2,opacity:.5}));
       const total=window.GameRules.BOARD.track.length; const startIdx=window.GameRules.BOARD.track.startIndex; const entryIdx=window.GameRules.BOARD.homeLane.entryIndex; const ownJump=window.GameRules.BOARD.special.ownColorJump.indices;
+      const specials=window.GameRules.BOARD.special||{};
+      const safeExtras=new Set((specials.safeTiles?.extra)||[]);
+      const powerLookup=new Map((specials.powerTiles||[]).map(p=>[p.idx,p]));
+      const trapLookup=new Map((specials.trapTiles||[]).map(t=>[t.idx,t]));
+      const portalLookup=new Map((specials.portals||[]).map(p=>[p.from,p]));
+      const portalPairs=new Map();
+      (specials.portals||[]).forEach(p=>{
+        if(!p || !p.label) return;
+        if(!portalPairs.has(p.label)) portalPairs.set(p.label,new Set());
+        const set=portalPairs.get(p.label);
+        set.add(p.from);
+        set.add(p.to);
+      });
       const defs=el('defs'); svg.insertBefore(defs, svg.firstChild);
       const jumpPatterns={};
       const ensureJumpPattern=(col)=>{
@@ -1012,9 +1111,45 @@
         const {x,y,angle}=ringPoint(i); geom.track[i]={x,y,angle};
         const attrs={x:x-tileSize/2,y:y-tileSize/2,width:tileSize,height:tileSize,rx:10,fill:'transparent',stroke:color('--tile-grid'),'stroke-width':2};
         const jumpCol=ownJumpLookup[i];
+        if(!jumpCol && safeExtras.has(i)){ attrs.fill='rgba(148,163,184,0.18)'; attrs.stroke='rgba(148,163,184,0.65)'; }
         if(jumpCol){ const hex=color(`--${jumpCol}`); attrs.fill=mixWithWhite(hex,0.15); attrs['fill-opacity']=0.9; attrs.stroke=withAlpha(hex,0.6); attrs['stroke-width']=2.5; }
         gTiles.appendChild(el('rect',attrs));
         if(jumpCol){ ensureJumpPattern(jumpCol); gTiles.appendChild(el('rect',{x:x-tileSize/2,y:y-tileSize/2,width:tileSize,height:tileSize,rx:10,fill:`url(#jump-${jumpCol})`,opacity:0.5})); }
+        const power=powerLookup.get(i);
+        if(power){
+          const accent=color('--accent');
+          gSpecials.appendChild(el('circle',{cx:x,cy:y,r:tileSize*0.32,fill:withAlpha(accent,0.18),stroke:accent,'stroke-width':2.4}));
+          const label=document.createTextNode(power.label||'⚡');
+          gSpecials.appendChild(el('text',{x, y:y+5, 'text-anchor':'middle','font-size':'16','font-weight':'700','fill':accent},[label]));
+        }
+        const trap=trapLookup.get(i);
+        if(trap){
+          const red=color('--red');
+          gSpecials.appendChild(el('rect',{x:x-tileSize*0.32,y:y-tileSize*0.32,width:tileSize*0.64,height:tileSize*0.64,rx:10,fill:withAlpha(red,0.18),stroke:withAlpha(red,0.6),'stroke-width':2.2}));
+          const label=document.createTextNode(trap.label||'⚠');
+          gSpecials.appendChild(el('text',{x, y:y+5, 'text-anchor':'middle','font-size':'16','font-weight':'700','fill':red},[label]));
+        }
+        const portal=portalLookup.get(i);
+        if(portal){
+          const accent=color('--accent');
+          gSpecials.appendChild(el('circle',{cx:x,cy:y,r:tileSize*0.34,fill:withAlpha(accent,0.16),stroke:accent,'stroke-width':2.4,'stroke-dasharray':'6 4'}));
+          const label=document.createTextNode(portal.label||'🌀');
+          gSpecials.appendChild(el('text',{x, y:y+5, 'text-anchor':'middle','font-size':'15','font-weight':'700','fill':accent},[label]));
+        }
+      }
+      if(portalPairs.size>0){
+        const portalLines=el('g',{opacity:0.45});
+        portalPairs.forEach((set,label)=>{
+          const points=Array.from(set).map(idx=>geom.track[idx]).filter(Boolean);
+          if(points.length>=2){
+            const [p1,p2]=points;
+            portalLines.appendChild(el('line',{x1:p1.x,y1:p1.y,x2:p2.x,y2:p2.y,stroke:color('--accent'),'stroke-dasharray':'8 6','stroke-width':2}));
+            const mid={x:(p1.x+p2.x)/2,y:(p1.y+p2.y)/2};
+            const labelNode=document.createTextNode(`🌀${label}`);
+            portalLines.appendChild(el('text',{x:mid.x,y:mid.y-8,'text-anchor':'middle','font-size':'12','font-weight':'600','fill':color('--accent')},[labelNode]));
+          }
+        });
+        gSpecials.appendChild(portalLines);
       }
       const startIndexByColor=Object.fromEntries(Object.entries(startIdx).map(([col,idx])=>[idx,col]));
       const entryIndexByColor=Object.fromEntries(Object.entries(entryIdx).map(([col,idx])=>[idx,col]));
@@ -1080,8 +1215,33 @@
         }
       });
       gGrid.appendChild(el('rect',{x:cx-60,y:cy-60,width:120,height:120,transform:`rotate(45 ${cx} ${cy})`,fill:'#0f172a',stroke:color('--tile-grid'),'stroke-width':2}));
+      gSpecials.appendChild(el('polygon',{points:starPoints(cx,cy,70,28),fill:withAlpha(color('--accent'),0.16),stroke:color('--accent'),'stroke-width':2.4}));
       const baseDefs={red:{dx:-350,dy:-350},blue:{dx:350,dy:-350},yellow:{dx:350,dy:350},green:{dx:-350,dy:350}};
-      for(const [col,{dx,dy}] of Object.entries(baseDefs)){ const group=el('g',{}); const x=cx+dx,y=cy+dy,w=180,h=180; group.appendChild(el('rect',{x:x-w/2,y:y-h/2,width:w,height:h,rx:22,fill:`var(--${col})`,opacity:.14,stroke:`var(--${col})`,'stroke-width':2})); const slots=[]; for(let i=-1;i<=1;i+=2){ for(let j=-1;j<=1;j+=2){ const sx=x+i*40,sy=y+j*40; slots.push({x:sx,y:sy}); group.appendChild(el('circle',{cx:sx,cy:sy,r:22,fill:'none',stroke:`var(--${col})`,'stroke-width':2,opacity:.8})); } } geom.bases[col]=slots; gGrid.appendChild(group); }
+      const runwayGroup=el('g',{});
+      const runwayLength=4;
+      for(const [col,{dx,dy}] of Object.entries(baseDefs)){
+        const group=el('g',{});
+        const x=cx+dx,y=cy+dy,w=180,h=180;
+        group.appendChild(el('rect',{x:x-w/2,y:y-h/2,width:w,height:h,rx:22,fill:`var(--${col})`,opacity:.14,stroke:`var(--${col})`,'stroke-width':2}));
+        const slots=[];
+        for(let i=-1;i<=1;i+=2){ for(let j=-1;j<=1;j+=2){ const sx=x+i*40,sy=y+j*40; slots.push({x:sx,y:sy}); group.appendChild(el('circle',{cx:sx,cy:sy,r:22,fill:'none',stroke:`var(--${col})`,'stroke-width':2,opacity:.8})); } }
+        geom.bases[col]=slots;
+        const startTile=geom.track[startIdx[col]];
+        if(startTile){
+          const vec={x:startTile.x-x,y:startTile.y-y};
+          const segLen=Math.hypot(vec.x,vec.y)||1;
+          const unit={x:vec.x/(runwayLength+1),y:vec.y/(runwayLength+1)};
+          geom.runway[col]=[];
+          for(let step=1;step<=runwayLength;step++){
+            const px=x+unit.x*step;
+            const py=y+unit.y*step;
+            geom.runway[col].push({x:px,y:py});
+            runwayGroup.appendChild(el('rect',{x:px-tileSize/2,y:py-tileSize/2,width:tileSize,height:tileSize,rx:10,fill:withAlpha(color(`--${col}`),0.12),stroke:withAlpha(color(`--${col}`),0.55),'stroke-width':2}));
+          }
+        }
+        gGrid.appendChild(group);
+      }
+      gSpecials.appendChild(runwayGroup);
       gGrid.appendChild(el('circle',{cx,cy,r:r+150,fill:'none',stroke:'#000','stroke-width':140,opacity:.35}));
     }
 ,
@@ -1170,6 +1330,9 @@
         if(move.events.some(ev=>ev.type==='jump')) parts.push('跳格');
         if(move.events.some(ev=>ev.type==='flight')) parts.push('飛行');
         if(move.events.some(ev=>ev.type==='finish')) parts.push('終點');
+        if(move.events.some(ev=>ev.type==='portal')) parts.push('傳送');
+        if(move.events.some(ev=>ev.type==='power-up')) parts.push('增益');
+        if(move.events.some(ev=>ev.type==='trap')) parts.push('陷阱');
       }
       const capturedCount=Array.isArray(move.capture?.captured)?move.capture.captured.length:0;
       if(capturedCount>0) parts.push('吃子');
@@ -1233,6 +1396,7 @@
     applyMove(move,source='system'){
       if(!move) return;
       if(!this.isInteractionPermitted(source)){ this.handleBlockedInteraction(source); return; }
+      const wasBonusMove=this.state.bonusSelecting===true;
       this.pushHistory();
       const pid=this.state.turn;
       const player=this.currentPlayer();
@@ -1304,12 +1468,40 @@
           this.log(`${player.name} 疊子合體移動（${movingPieces.length} 枚）`);
         }
 
+        let extraTurnFromEvent=false;
+        let pendingBonusRequest=null;
         if(move.events){
           move.events.forEach(ev=>{
             if(ev.type==='enter-home') this.log(`${player.name} 進入家路`);
-            if(ev.type==='jump') this.log(`${player.name} 觸發跳格 (+${this.state.rules?.ownColorJump?.steps||0})`);
-            if(ev.type==='flight') this.log(`${player.name} 走飛線`);
-            if(ev.type==='finish') this.log(`${player.name} 抵達終點！`);
+            else if(ev.type==='jump') this.log(`${player.name} 觸發跳格 (+${this.state.rules?.ownColorJump?.steps||0})`);
+            else if(ev.type==='flight') this.log(`${player.name} 走飛線`);
+            else if(ev.type==='finish') this.log(`${player.name} 抵達終點！`);
+            else if(ev.type==='portal'){
+              const label=ev.label?` ${ev.label}`:'';
+              this.log(`${player.name} 穿越傳送門${label}`);
+              this.showToast(`🌀 傳送門${label||''}！` ,1200);
+            }
+            else if(ev.type==='power-up'){
+              if(ev.effect==='extra-roll'){
+                extraTurnFromEvent=true;
+                this.log(`${player.name} 拿到增擲機會！`);
+                this.showToast('🎲 加擲機會！',1400);
+              }else if(ev.effect==='advance-2'){
+                pendingBonusRequest=pendingBonusRequest||{dice:2,restrict:'same',pieceIndex:leadEntry.idx,description:'向前再飛 2 格',source:'power-up',autoResolve:true};
+                this.log(`${player.name} 動力提升，準備再飛 2 格`);
+              }else if(ev.effect==='command-other'){
+                pendingBonusRequest={dice:1,restrict:'others',pieceIndex:leadEntry.idx,description:'指揮另一架飛機前進 1 格',source:'power-up',autoResolve:false};
+                this.log(`${player.name} 獲得指揮權，可讓另一架棋子前進 1 格`);
+              }
+            }
+            else if(ev.type==='trap'){
+              if(ev.effect==='skip-turn'){
+                const currentSkip=Math.max(0,this.state.skipTurns[player.id]||0);
+                this.state.skipTurns[player.id]=currentSkip+1;
+                this.log(`${player.name} 遭遇亂流，下一回合將停飛`);
+                this.showToast('⚠️ 亂流！下回合停飛',1600);
+              }
+            }
           });
         }
 
@@ -1320,37 +1512,91 @@
           const faces=this.computeThreatFaces(move.to.idx);
           this.showThreatBadge(toXY.x,toXY.y,faces);
         }else{
-        this.showThreatBadge(toXY.x,toXY.y,[]);
-      }
+          this.showThreatBadge(toXY.x,toXY.y,[]);
+        }
 
-      const again=(this.state.dice===6 && this.state.rules?.extraTurnOnSix);
-      this.state.animating=false;
-      this.renderHints();
-      if(!again){
-        this.advanceTurn();
-      }else{
+        this.state.animating=false;
+
+        if(pendingBonusRequest){
+          this.state.pendingBonus=pendingBonusRequest;
+          this.state.bonusSelecting=true;
+          this.state.dice=pendingBonusRequest.dice;
+          this.$.diceOut.textContent=String(pendingBonusRequest.dice);
+          this.state.legalMoves=[];
+          this.refreshLegalMoves();
+          if((this.state.legalMoves||[]).length===0){
+            this.log('增益移動未能觸發');
+            this.state.bonusSelecting=false;
+            this.state.pendingBonus=null;
+            this.state.dice=null;
+            this.$.diceOut.textContent='–';
+          }else{
+            this.renderHints();
+            this.updateTurnUI();
+            this.updateTurnPrompt(true);
+            this.saveGame();
+            const needsChoice=(pendingBonusRequest.autoResolve===false) || (this.state.legalMoves.length>1);
+            if(needsChoice) this.maybeAutoPlayIfAI();
+            if(pendingBonusRequest.autoResolve!==false && this.state.legalMoves.length===1){
+              const autoMove=this.state.legalMoves[0];
+              requestAnimationFrame(()=>this.applyMove(autoMove,'system'));
+            }
+            return;
+          }
+        }
+
+        if(wasBonusMove){
+          this.state.bonusSelecting=false;
+        }
+        this.state.pendingBonus=null;
         this.state.dice=null;
         this.$.diceOut.textContent='–';
-        this.state.legalMoves=[];
-        this.clearTurnTimer();
-        this.beginTurnTimer();
-        this.saveGame();
-        this.updateTurnUI();
-        this.updateTurnPrompt(true);
-        this.maybeAutoPlayIfAI();
-      }
-    });
-  },
+
+        const rolledValue=move.dice;
+        const again=(!wasBonusMove && (((rolledValue===6)&&this.state.rules?.extraTurnOnSix) || extraTurnFromEvent));
+        this.renderHints();
+        if(!again){
+          this.advanceTurn();
+        }else{
+          this.state.legalMoves=[];
+          this.clearTurnTimer();
+          this.beginTurnTimer();
+          this.saveGame();
+          this.updateTurnUI();
+          this.updateTurnPrompt(true);
+          this.maybeAutoPlayIfAI();
+        }
+      });
+    },
     advanceTurn(){
       if(!Array.isArray(this.state.players) || this.state.players.length===0) return;
       if(this._noMoveTimer){ clearTimeout(this._noMoveTimer); this._noMoveTimer=null; }
-      const currentIdx=this.state.players.findIndex(p=>p.id===this.state.turn);
-      const next=(currentIdx<0?0:(currentIdx+1)%this.state.players.length);
       const prevId=this.state.turn;
-      const nextId=this.state.players[next].id;
+      const playerCount=this.state.players.length;
       if(prevId!=null && this.state.consecutiveSixes){ this.state.consecutiveSixes[prevId]=0; }
-      this.state.turn=nextId;
-      if(this.state.consecutiveSixes){ this.state.consecutiveSixes[nextId]=0; }
+      const currentIdx=this.state.players.findIndex(p=>p.id===prevId);
+      let idx=(currentIdx<0?0:(currentIdx+1)%playerCount);
+      let target=null;
+      let attempts=0;
+      while(attempts<playerCount){
+        const candidate=this.state.players[idx];
+        const skipCount=Math.max(0,this.state.skipTurns?.[candidate.id]||0);
+        if(skipCount>0){
+          this.state.skipTurns[candidate.id]=skipCount-1;
+          this.log(`${candidate.name} 被亂流困住，跳過此回合`);
+          this.showToast(`${candidate.name} 暫停一回合`,1200);
+          attempts+=1;
+          idx=(idx+1)%playerCount;
+          continue;
+        }
+        target=candidate;
+        break;
+      }
+      if(!target){
+        target=this.state.players[idx];
+      }
+      if(this.state.consecutiveSixes){ this.state.consecutiveSixes[target.id]=0; }
+      this.state.turn=target.id;
       this.state.dice=null;
       this.state.legalMoves=[];
       this.$.diceOut.textContent='–';
@@ -1391,7 +1637,7 @@
     },
 
     // --------- Persistence / Undo ---------
-    snapshot(){ return JSON.parse(JSON.stringify({players:this.state.players,pieces:this.state.pieces,turn:this.state.turn,rules:this.state.rules,dice:this.state.dice,consecutiveSixes:this.state.consecutiveSixes})); },
+    snapshot(){ return JSON.parse(JSON.stringify({players:this.state.players,pieces:this.state.pieces,turn:this.state.turn,rules:this.state.rules,dice:this.state.dice,consecutiveSixes:this.state.consecutiveSixes,skipTurns:this.state.skipTurns,bonusSelecting:this.state.bonusSelecting,pendingBonus:this.state.pendingBonus})); },
     saveGame(){ try{ localStorage.setItem('ac_save_v1', JSON.stringify(this.snapshot())); }catch(e){} },
     loadGame(){ try{ const s=localStorage.getItem('ac_save_v1'); return s?JSON.parse(s):null; }catch(e){ return null; } },
     clearSave(){ try{ localStorage.removeItem('ac_save_v1'); }catch(e){} },
@@ -1404,8 +1650,12 @@
       this.state.turn=snapshot.turn||null;
       const loadedRules=snapshot.rules? Object.assign({}, window.GameRules.DEFAULT_RULES, snapshot.rules) : window.GameRules.DEFAULT_RULES;
       this.state.rules=loadedRules;
+      this.applyBoardDefaultsToRules();
       this.state.dice=snapshot.dice??null;
       this.state.consecutiveSixes=snapshot.consecutiveSixes||{};
+      this.state.skipTurns=snapshot.skipTurns||{};
+      this.state.bonusSelecting=!!snapshot.bonusSelecting;
+      this.state.pendingBonus=snapshot.pendingBonus||null;
       this.state.history=[];
       this.normalizePieces();
       this.updateControlAssignments();
@@ -1414,6 +1664,13 @@
       this.redrawPieces();
       this.clearTurnTimer();
       this.beginTurnTimer();
+      if(this.state.bonusSelecting && this.state.dice!=null){
+        this.refreshLegalMoves();
+      }else{
+        this.state.legalMoves=[];
+        this.highlightMovables();
+      }
+      this.renderHints();
       this.updateTurnUI();
       this.updateTurnPrompt(true);
       this.log('已載入上局');


### PR DESCRIPTION
## Summary
- define power-up, trap, and portal specials in the board spec with default safe tiles
- handle teleporters, bonus actions, and skip-turn traps in move resolution and UI prompts
- refresh the SVG board with runway strips, portal links, center star, and special tile indicators

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e18fd8019883219b3b7522e174d0ec