### PR TITLE
Fix home entry step accounting

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -607,6 +607,10 @@
             if(allowEntry){
               current=Pos.home(0); recordPosition(current);
               events.push({type:'enter-home'});
+              if(remaining>0){
+                remaining-=1;
+                stepsTaken+=1;
+              }
             }
           }
         } else if(current.kind==='home'){


### PR DESCRIPTION
## Summary
- ensure that entering the home lane consumes a movement step when dice remain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e28e2771bc8321a71198b783d93bc0