### PR TITLE
Fix flight event logging after chained jumps

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -676,7 +676,13 @@
       const flightRule = rules.dashedFlight||{};
       if(flightsEnabled && flightRule.enabled && current.kind==='track'){
         const to = flightTo(player.color,current.idx);
-        if(to!=null){ current=Pos.track(to); events.push({type:'flight',from:pos.idx,to}); viaFlight=true; recordPosition(current); }
+        if(to!=null){
+          const flightFrom=current.idx;
+          current=Pos.track(to);
+          events.push({type:'flight',from:flightFrom,to});
+          viaFlight=true;
+          recordPosition(current);
+        }
       }
       const specialsConfig = rules.specials||{};
       const specialsActive = specialsConfig.enabled!==false;


### PR DESCRIPTION
## Summary
- record the track index used for flight launches inside `resolveSpecialsAfterLanding`
- ensure flight events capture the actual takeoff tile when triggered after a jump

## Testing
- node - <<'NODE' ... (scenario: red plane moves from track 1 with jump steps set to 2)


------
https://chatgpt.com/codex/tasks/task_e_68e28ec9c4b8832197cbbd6e519f158d