### PR TITLE
Ensure quick start button enforces classic preset

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -784,7 +784,15 @@
           if(custom) custom.checked=true;
         }
       });
-      this.$.btnQuick.addEventListener('click',()=>{ this.applyPreset('classic'); this.startGame(); });
+      this.$.btnQuick.addEventListener('click',()=>{
+        const radios=this.$.formSetup?.querySelectorAll('input[name="preset"]');
+        const classic=this.$.formSetup?.querySelector('input[name="preset"][value="classic"]');
+        if(radios && classic){
+          radios.forEach(radio=>{ radio.checked = (radio===classic); });
+        }
+        this.applyPreset('classic');
+        this.startGame();
+      });
       this.$.btnContinue.addEventListener('click',()=>this.continueFromSave());
       this.$.btnLobby.addEventListener('click',()=>this.toLobby());
       if(this.$.btnReplayLast){


### PR DESCRIPTION
## Summary
- ensure the quick start button reselects the classic preset radio option before starting a game

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a732169c8321bfac9a95852661c8