### PR TITLE
Handle single legal move on space key

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -2755,7 +2755,15 @@
       if(isSpace){
         e.preventDefault();
         if(!this.isInteractionPermitted('keyboard')){ this.handleBlockedInteraction('keyboard'); return; }
-        this.rollDice('keyboard');
+        const legalMoves=Array.isArray(this.state.legalMoves)?this.state.legalMoves:[];
+        const hasSingleLegalMove=(legalMoves.length===1);
+        const hasDice=this.state.dice!=null;
+        const bonusActive=!!(this.state.pendingBonus||this.state.bonusSelecting);
+        if(hasSingleLegalMove && (hasDice || bonusActive)){
+          this.applyMove(legalMoves[0],'keyboard');
+        }else{
+          this.rollDice('keyboard');
+        }
         return;
       }
       if(!this.isInteractionPermitted('keyboard')){ this.handleBlockedInteraction('keyboard'); return; }


### PR DESCRIPTION
## Summary
- adjust keyboard space-bar handling to detect the current move phase
- auto-apply the lone legal move when keyboard interaction is allowed
- keep rolling the dice when no moves are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e417debe108321aa1102c8fd122d72