### PR TITLE
Fix piece layer ordering over board highlights

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -2275,8 +2275,8 @@
         if(gGrid) gGrid.appendChild(group);
       }
       gSpecials.appendChild(gRunways);
-      if(svg && this.$?.gPieces) svg.appendChild(this.$.gPieces);
       if(svg && this.$?.gHL) svg.appendChild(this.$.gHL);
+      if(svg && this.$?.gPieces) svg.appendChild(this.$.gPieces);
       this.clearGhostPath();
     },
     clearGhostPath(){


### PR DESCRIPTION
## Summary
- ensure the highlights layer is re-appended before the pieces layer so tokens stay above the map graphics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6668a969c83219651648f7f947ce3