### PR TITLE
Guard buildOccupancy against missing player piece lists

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -514,10 +514,13 @@
     function buildOccupancy(state){
       const occ={ track:Array(BOARD.track.length).fill(0).map(()=>({})), home:{} };
       const players=Array.isArray(state?.players)?state.players:[];
-      const piecesByPlayer=(state&&typeof state==='object'&&state.pieces)?state.pieces:{};
+      const piecesByPlayer=(state&&typeof state==='object'&&state.pieces&&typeof state.pieces==='object')?state.pieces:{};
       for(const player of players){
-        const pieces=Array.isArray(piecesByPlayer[player.id])?piecesByPlayer[player.id]:[];
-        for(const pc of pieces){
+        if(!player || typeof player!=='object') continue;
+        const playerId=player.id;
+        if(typeof playerId!=='string'&&typeof playerId!=='number') continue;
+        const playerPieces=Array.isArray(piecesByPlayer[playerId])?piecesByPlayer[playerId]:[];
+        for(const pc of playerPieces){
           const pos=pc?.pos;
           if(!pos) continue;
           if(pos.kind==='track'){


### PR DESCRIPTION
## Summary
- guard buildOccupancy against malformed player entries and missing piece arrays to prevent iteration errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e667e2c6988321a20c52e5821fdf16