### PR TITLE
Fix undefined player label when logging captures

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -2682,6 +2682,7 @@
       this.pushHistory();
       const pid=this.state.turn;
       const player=this.currentPlayer();
+      const playerLabel=this.formatPlayerName(player,{includeDifficulty:true});
       let movingIndices=Array.isArray(move.stack)?move.stack.slice():[move.pieceIndex];
       if(!movingIndices.includes(move.pieceIndex)) movingIndices.push(move.pieceIndex);
       movingIndices=Array.from(new Set(movingIndices)).sort((a,b)=>a-b);


### PR DESCRIPTION
## Summary
- define the player label in `App.applyMove` before using it for capture and stack logs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e66c9b30dc832184253ed2706fd9c3