### PR TITLE
Fix victory celebration triggering for non-winning players

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -2798,12 +2798,13 @@
         },0);
         if(finishedCount>=perPlayerPieces && !this.state.finishOrder.includes(pid)){
           this.state.finishOrder.push(pid);
-          if(!this.state.winner) this.state.winner=pid;
+          const isFirstFinisher=!this.state.winner;
+          if(isFirstFinisher) this.state.winner=pid;
           this.state.disabledColors[pid]=true;
-          if(typeof window!=='undefined' && typeof window.showWinnerEffect==='function'){
+          if(isFirstFinisher && typeof window!=='undefined' && typeof window.showWinnerEffect==='function'){
             try{ window.showWinnerEffect(pid); }catch(err){ console.warn('showWinnerEffect failed',err); }
           }
-          if(typeof window!=='undefined' && typeof window.showWinnerModal==='function'){
+          if(isFirstFinisher && typeof window!=='undefined' && typeof window.showWinnerModal==='function'){
             try{ window.showWinnerModal(pid,{finishOrder:this.state.finishOrder}); }catch(err){ /* noop */ }
           }
           const emitter=(typeof window!=='undefined' && typeof window.emit==='function')?window.emit:null;


### PR DESCRIPTION
## Summary
- ensure the victory celebration and modal only trigger for the first player who finishes
- continue emitting the playerFinished event for later finishers without replaying the celebration

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e66c9b30dc832184253ed2706fd9c3