### PR TITLE
Allow animations to continue when tab hidden

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -915,6 +915,7 @@
     }catch(e){ return false; }
   })();
   const COLOR_LABELS={red:'紅',blue:'藍',yellow:'黃',green:'綠'};
+  const isDocumentHidden = ()=> typeof document!=='undefined' && document.visibilityState==='hidden';
   const openDialogSafe = (dialog)=>{
     if(!dialog) return;
     if(supportsDialog && typeof dialog.showModal==='function'){
@@ -958,6 +959,15 @@
   const App = {
     state:{ view:'lobby', players:[], rules:null, pieces:{}, turn:null, dice:null, history:[], settings:{keyboardMode:'shared',theme:'dark'}, animating:false, consecutiveSixes:{}, turnTimerId:null, turnTimerRemaining:0, controlById:{}, inputLockUntil:0, bonusSelecting:false, pendingBonus:null, skipTurns:{}, lastMoveSummary:null, finishOrder:[], winner:null, disabledColors:{}, finishedSlots:{} },
     geom:{ track:[], home:{}, bases:{}, runway:{}, finishedSlots:{} },
+    runSoon(callback){
+      if(typeof callback!=='function') return;
+      const useRAF = typeof window!=='undefined' && typeof window.requestAnimationFrame==='function' && !isDocumentHidden();
+      if(useRAF){
+        window.requestAnimationFrame(()=>callback());
+      }else{
+        setTimeout(()=>callback(),0);
+      }
+    },
     init(){
       if(this._initialized) return;
       this._initialized=true;
@@ -2958,7 +2968,7 @@
             if(needsChoice) this.maybeAutoPlayIfAI();
             if(pendingBonusRequest.autoResolve!==false && this.state.legalMoves.length===1){
               const autoMove=this.state.legalMoves[0];
-              requestAnimationFrame(()=>this.applyMove(autoMove,'system'));
+              this.runSoon(()=>this.applyMove(autoMove,'system'));
             }
             return;
           }
@@ -3667,7 +3677,7 @@
     },
 
     // --------- Anim / Effects ---------
-    animatePiece(player,from,to,duration=480,path=null){ duration=this.getAnimDuration(duration); return new Promise(resolve=>{ const g=this.$.gHL; if(!g){ resolve(); return; } const NS='http://www.w3.org/2000/svg'; const ghost=document.createElementNS(NS,'circle'); ghost.setAttribute('cx',from.x); ghost.setAttribute('cy',from.y); ghost.setAttribute('r',18); ghost.setAttribute('fill',`var(--${player.color})`); ghost.setAttribute('stroke','#0b0f14'); ghost.setAttribute('stroke-width','3'); g.appendChild(ghost); const coords=Array.isArray(path)&&path.length>1?path.map(pt=>({x:pt.x,y:pt.y})):[{x:from.x,y:from.y},{x:to.x,y:to.y}]; if(coords.length<2){ coords.push({x:to.x,y:to.y}); } const segments=[]; for(let i=0;i<coords.length-1;i++){ const start=coords[i]; const end=coords[i+1]; const len=Math.hypot(end.x-start.x,end.y-start.y); segments.push({start,end,len:len||0.0001}); } if(segments.length===0){ if(ghost.parentNode) ghost.parentNode.removeChild(ghost); resolve(); return; } const totalLen=segments.reduce((acc,seg)=>acc+seg.len,0)||1; const ease=t=>1-Math.pow(1-t,3); const t0=performance.now(); const step=(now)=>{ const raw=Math.min(1,(now-t0)/duration); const eased=ease(raw); const targetDist=totalLen*eased; let traversed=0; let segmentIndex=0; while(segmentIndex<segments.length-1 && traversed+segments[segmentIndex].len<targetDist){ traversed+=segments[segmentIndex].len; segmentIndex++; } const segment=segments[segmentIndex]; const segLen=segment.len||1; const local=(segLen===0)?1:Math.min(1,(targetDist-traversed)/segLen); const x=segment.start.x+(segment.end.x-segment.start.x)*local; const y=segment.start.y+(segment.end.y-segment.start.y)*local; ghost.setAttribute('cx',x); ghost.setAttribute('cy',y); if(raw<1){ requestAnimationFrame(step); }else{ if(ghost.parentNode) ghost.parentNode.removeChild(ghost); resolve(); } }; requestAnimationFrame(step); }); },
+    animatePiece(player,from,to,duration=480,path=null){ duration=this.getAnimDuration(duration); return new Promise(resolve=>{ const g=this.$.gHL; if(!g){ resolve(); return; } const NS='http://www.w3.org/2000/svg'; const ghost=document.createElementNS(NS,'circle'); ghost.setAttribute('cx',from.x); ghost.setAttribute('cy',from.y); ghost.setAttribute('r',18); ghost.setAttribute('fill',`var(--${player.color})`); ghost.setAttribute('stroke','#0b0f14'); ghost.setAttribute('stroke-width','3'); g.appendChild(ghost); const coords=Array.isArray(path)&&path.length>1?path.map(pt=>({x:pt.x,y:pt.y})):[{x:from.x,y:from.y},{x:to.x,y:to.y}]; if(coords.length<2){ coords.push({x:to.x,y:to.y}); } const segments=[]; for(let i=0;i<coords.length-1;i++){ const start=coords[i]; const end=coords[i+1]; const len=Math.hypot(end.x-start.x,end.y-start.y); segments.push({start,end,len:len||0.0001}); } if(segments.length===0){ if(ghost.parentNode) ghost.parentNode.removeChild(ghost); resolve(); return; } const totalLen=segments.reduce((acc,seg)=>acc+seg.len,0)||1; const ease=t=>1-Math.pow(1-t,3); const t0=performance.now(); let fallbackTimerId=null; const scheduleStep=(handler)=>{ if(typeof window!=='undefined' && typeof window.requestAnimationFrame==='function' && !isDocumentHidden()){ window.requestAnimationFrame(handler); }else{ fallbackTimerId=setTimeout(()=>{ fallbackTimerId=null; handler(performance.now()); },16); } }; const step=(now)=>{ const raw=Math.min(1,(now-t0)/duration); const eased=ease(raw); const targetDist=totalLen*eased; let traversed=0; let segmentIndex=0; while(segmentIndex<segments.length-1 && traversed+segments[segmentIndex].len<targetDist){ traversed+=segments[segmentIndex].len; segmentIndex++; } const segment=segments[segmentIndex]; const segLen=segment.len||1; const local=(segLen===0)?1:Math.min(1,(targetDist-traversed)/segLen); const x=segment.start.x+(segment.end.x-segment.start.x)*local; const y=segment.start.y+(segment.end.y-segment.start.y)*local; ghost.setAttribute('cx',x); ghost.setAttribute('cy',y); if(raw<1){ scheduleStep(step); }else{ if(ghost.parentNode) ghost.parentNode.removeChild(ghost); if(fallbackTimerId!=null){ clearTimeout(fallbackTimerId); fallbackTimerId=null; } resolve(); } }; scheduleStep(step); }); },
     pulseAt(x,y,color){ const g=this.$.gHL; if(!g) return; const NS='http://www.w3.org/2000/svg'; const ring=document.createElementNS(NS,'circle'); ring.setAttribute('cx',x); ring.setAttribute('cy',y); ring.setAttribute('r','8'); ring.setAttribute('fill','none'); ring.setAttribute('stroke',color); ring.setAttribute('stroke-width','3'); ring.setAttribute('opacity','0.9'); g.appendChild(ring); let r=8; const id=setInterval(()=>{ r+=4; ring.setAttribute('r',r); const op=parseFloat(ring.getAttribute('opacity')); ring.setAttribute('opacity',String(Math.max(0,op-0.12))); if(r>36){ clearInterval(id); if(ring.parentNode) ring.parentNode.removeChild(ring);} },16); },
     computeThreatFaces(targetIdx){ const L=window.GameRules.BOARD.track.length; const me=this.currentPlayer(); const faces=new Set(); for(const opp of this.state.players){ if(opp.id===me.id) continue; const oppPieces=this.state.pieces[opp.id]||[]; for(const pc of oppPieces){ if(pc.pos.kind!=='track') continue; const d=((targetIdx-pc.pos.idx)%L+L)%L; if(d>=1&&d<=6) faces.add(d); } } return Array.from(faces).sort((a,b)=>a-b); },
     showThreatBadge(x,y,faces){ const g=this.$.gHL; g.querySelectorAll('.threat-badge').forEach(n=>n.remove()); if(!faces||faces.length===0) return; const NS='http://www.w3.org/2000/svg'; const bx=x+26,by=y-26; const badge=document.createElementNS(NS,'g'); badge.setAttribute('class','threat-badge'); const rect=document.createElementNS(NS,'rect'); const label=faces.join('/'); const padding=6; const width=Math.max(24,label.length*7+padding*2); rect.setAttribute('x',bx-width/2); rect.setAttribute('y',by-10); rect.setAttribute('width',width); rect.setAttribute('height',20); rect.setAttribute('rx',6); rect.setAttribute('fill','#ef4444'); rect.setAttribute('stroke','#000'); rect.setAttribute('stroke-width','2'); const txt=document.createElementNS(NS,'text'); txt.setAttribute('x',bx); txt.setAttribute('y',by+5); txt.setAttribute('text-anchor','middle'); txt.setAttribute('font-size','12'); txt.setAttribute('fill','#0b0f14'); txt.textContent=label; badge.appendChild(rect); badge.appendChild(txt); g.appendChild(badge); }


### PR DESCRIPTION
## Summary
- add a helper to detect hidden documents and schedule work without relying on requestAnimationFrame
- update auto-move resolution and piece animation to use the helper so the game keeps running in background tabs

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e66f852bb48321a8f7552ccd250366