### PR TITLE
Fix GameRules helpers to run outside the browser

### DIFF
--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -604,7 +604,7 @@
     };
 
     const mod = (n,m)=>((n%m)+m)%m;
-    const clone = (x)=> (window.structuredClone? structuredClone(x) : JSON.parse(JSON.stringify(x)));
+    const clone = (x)=> (typeof structuredClone==='function' ? structuredClone(x) : JSON.parse(JSON.stringify(x)));
     const SPECIAL_RESOLUTION_ORDER = Object.freeze(['own-color-jump','flight','portal','power-up','trap']);
 
     const Pos = {
@@ -882,7 +882,7 @@
       const specialsConfig = rules.specials||{};
       const specialsActive = specialsConfig.enabled!==false;
       const portalLimit = Math.max(0, specialsConfig.portalLimit ?? 1);
-      const portalLookup=window.GameRules?.SPECIAL_BY_IDX||{};
+      const portalLookup = SPECIAL_BY_IDX || {};
       const visitedPortals=new Set();
       let portalCount=0;
       while(specialsActive && current.kind==='track'){


### PR DESCRIPTION
## Summary
- replace the structured clone helper to avoid accessing `window` when it is unavailable
- reuse the local SPECIAL_BY_IDX map during special resolution instead of reading from `window`

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67f4c7ad48321acb0018d6d0d780b