### PR TITLE
feat: refine ai difficulty heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Skybound Flight Chess 是針對傳統飛行棋玩法打造的瀏覽器 MVP 介�
 - **主題切換與上一步回放**：支援深色／淺色／高對比主題即時切換，並在側邊欄顯示最近一步行動摘要與「重播上一步」路徑高亮。
 - **回合控制**：內建 Undo、重開局、暫停回合（亂流）、倒數計時與 AI 自動出手。
 - **無障礙考量**：語意化結構、ARIA 標籤與鍵盤操作提示，確保主要互動皆可使用鍵盤完成。
+- **AI 難度決策調校 / Difficulty-tailored AI**：AI 現在會依照難度改變保守程度、追趕策略與風險評估，提供由易到難的層次化挑戰。
 
 ## 特殊格行為：亂流陷阱（Trap Tile）
 在預設棋盤上，索引為 12、25、38、51 的格子標記為陷阱（圖示 `⚠`）。當棋子停在這些格子上時會觸發以下流程：
@@ -131,6 +132,18 @@ Skybound Flight Chess 是針對傳統飛行棋玩法打造的瀏覽器 MVP 介�
 - `pulseAt(x, y, color)`：於特定座標顯示脈衝效果。
 - `computeThreatFaces(targetIdx)`：計算敵方可能襲擊指定格子的骰面值。
 - `showThreatBadge(x, y, faces)`：顯示對應威脅骰值的提醒徽章。
+
+## AI Difficulty Refinements（AI 難度決策優化）
+
+### English
+- **Easy**：Prefers getting planes out of the base and staying on safer tiles, with extra randomness to keep the challenge relaxed.
+- **Normal**：Balances safety with steady progress, reacting more when trailing by prioritising catch-up moves and recovering from threats.
+- **Hard**：Evaluates exposure, blockades, and finishing tempo more deeply, rewarding captures and low-risk advances to pressure human players.
+
+### 繁體中文
+- **簡單**：偏好起飛與停留在安全格，並加入額外隨機性，營造輕鬆節奏。
+- **普通**：在安全與推進間取得平衡，落後時會更積極追趕並降低受威脅的機率。
+- **困難**：會進一步評估暴露度、堵路與終點節奏，優先吃子與低風險推進，對人類玩家形成壓力。
 
 ## Development Tips
 - 若需擴充邏輯，可將 `GameRules` 與 `App` 拆分為模組並補齊型別註記或測試。

--- a/skybound_flight_chess_interface.html
+++ b/skybound_flight_chess_interface.html
@@ -3942,18 +3942,72 @@
       };
       const myPieces=this.state.pieces[player.id]||[];
       const clonePos=(pos)=>this.clonePosition(pos);
-      const myPositions=myPieces.map(pc=>clonePos(pc?.pos));
       const buildTrackCounts=(positions)=>{
         const counts=Array(trackLength).fill(0);
         positions.forEach(pos=>{ if(pos?.kind==='track'){ counts[pos.idx]=(counts[pos.idx]||0)+1; } });
         return counts;
       };
-      const myTrackCounts=buildTrackCounts(myPositions);
+      const snapshotFor=(color,pieces)=>{
+        const positions=pieces.map(pc=>clonePos(pc?.pos));
+        const counts=buildTrackCounts(positions);
+        let finished=0;
+        let out=0;
+        let distSum=0;
+        let closest=Number.POSITIVE_INFINITY;
+        let furthest=0;
+        positions.forEach(pos=>{
+          if(!pos) return;
+          if(pos.kind==='finished') finished+=1;
+          if(pos.kind!=='base') out+=1;
+          const dist=distToFinish(color,pos);
+          distSum+=dist;
+          if(pos.kind!=='base' && pos.kind!=='finished'){
+            if(dist<closest) closest=dist;
+            if(dist>furthest) furthest=dist;
+          }
+        });
+        if(!Number.isFinite(closest)) closest=distSum;
+        return {
+          positions,
+          counts,
+          finished,
+          out,
+          distSum,
+          closest,
+          furthest,
+          exposure:computeExposureSum(positions,counts)
+        };
+      };
+      const mySnapshot=snapshotFor(player.color,myPieces);
+      const myPositions=mySnapshot.positions;
+      const myTrackCounts=mySnapshot.counts;
       const opponents=this.state.players.filter(p=>p.id!==player.id);
-      const opponentPieces=[];
-      opponents.forEach(opp=>{
-        (this.state.pieces[opp.id]||[]).forEach(pc=>{ if(pc?.pos) opponentPieces.push({color:opp.color,pos:clonePos(pc.pos)}); });
+      const opponentSnapshots=opponents.map(opp=>{
+        const pieces=this.state.pieces[opp.id]||[];
+        const snap=snapshotFor(opp.color,pieces);
+        return Object.assign({id:opp.id,color:opp.color},snap);
       });
+      const opponentPieces=[];
+      opponentSnapshots.forEach(snap=>{
+        snap.positions.forEach(pos=>{ if(pos) opponentPieces.push({color:snap.color,pos}); });
+      });
+      const bestDist=opponentSnapshots.length>0?Math.min(...opponentSnapshots.map(s=>s.distSum)):mySnapshot.distSum;
+      const worstDist=opponentSnapshots.length>0?Math.max(...opponentSnapshots.map(s=>s.distSum)):mySnapshot.distSum;
+      const bestExposure=opponentSnapshots.length>0?Math.min(...opponentSnapshots.map(s=>s.exposure)):mySnapshot.exposure;
+      const mostFinished=opponentSnapshots.length>0?Math.max(...opponentSnapshots.map(s=>s.finished)):mySnapshot.finished;
+      const mostOut=opponentSnapshots.length>0?Math.max(...opponentSnapshots.map(s=>s.out)):mySnapshot.out;
+      const behindCount=opponentSnapshots.filter(s=>s.distSum<mySnapshot.distSum).length;
+      const aheadCount=opponentSnapshots.filter(s=>s.distSum>mySnapshot.distSum).length;
+      const standing={
+        distGapToLeader:mySnapshot.distSum-bestDist,
+        distGapToLaggard:worstDist-mySnapshot.distSum,
+        exposureGap:mySnapshot.exposure-bestExposure,
+        finishedGap:mostFinished-mySnapshot.finished,
+        outGap:mostOut-mySnapshot.out,
+        behindCount,
+        aheadCount,
+        hasLead:mySnapshot.distSum<=bestDist && mySnapshot.finished>=mostFinished
+      };
       const threatDetailAt=(idx,{stackSize=1}={})=>{
         if(idx==null) return {prob:0,faces:new Set(),intensity:0};
         if(isSafeTile(player.color,idx)) return {prob:0,faces:new Set(),intensity:0};
@@ -4137,6 +4191,52 @@
           blockPressure
         };
       });
+      const tuneByDifficulty=()=>{
+        if(difficulty==='easy'){
+          scored.forEach(entry=>{
+            let adjust=0;
+            if(entry.safeValue>=1) adjust+=weights.W_safe*3*entry.safeValue;
+            if(entry.safePenalty>0) adjust-=weights.W_safe*4*entry.safePenalty;
+            if(entry.outGain) adjust+=weights.W_out*2.5;
+            if(entry.progress>=4) adjust+=weights.W_progress*0.4*entry.progress;
+            if(entry.threat.prob>0.25) adjust-=weights.W_risk*5*(entry.threat.prob-0.25);
+            entry.score+=adjust;
+            entry.score+=(Math.random()-0.5)*weights.W_tempo*4;
+          });
+          return;
+        }
+        if(difficulty==='normal'){
+          const catchUpFactor=Math.max(0,standing.distGapToLeader)/8;
+          scored.forEach(entry=>{
+            let adjust=0;
+            if(standing.outGap>0 && entry.outGain) adjust+=weights.W_out*3*Math.min(standing.outGap,2);
+            if(catchUpFactor>0 && entry.progress>0) adjust+=weights.W_progress*catchUpFactor*entry.progress*0.6;
+            if(entry.threatBefore.prob>0.45 && entry.threat.prob<entry.threatBefore.prob) adjust+=weights.W_risk*4;
+            if(standing.finishedGap<=0 && entry.endfit>0) adjust+=weights.W_endfit*3*entry.endfit;
+            entry.score+=adjust;
+            entry.score+=(Math.random()-0.5)*weights.W_tempo*2;
+          });
+          return;
+        }
+        if(difficulty==='hard'){
+          const catchUpFactor=Math.max(0,standing.distGapToLeader)/6;
+          const exposureRelief=Math.max(0,standing.exposureGap);
+          scored.forEach(entry=>{
+            let adjust=0;
+            if(catchUpFactor>0 && entry.progress>0) adjust+=weights.W_progress*(catchUpFactor*entry.progress*1.1);
+            if(entry.captureCount>0) adjust+=weights.W_eat*(2+Math.max(0,standing.finishedGap));
+            if(entry.threat.prob<entry.threatBefore.prob) adjust+=weights.W_risk*8*Math.max(0,entry.threatBefore.prob-entry.threat.prob);
+            if(entry.afterExposure<baseExposure) adjust+=weights.W_risk*6*(baseExposure-entry.afterExposure);
+            if(entry.safePenalty===0 && entry.safeValue>=1 && standing.hasLead) adjust+=weights.W_safe*4*entry.safeValue;
+            if(entry.endfit>2.4) adjust+=weights.W_endfit*6;
+            if(entry.blockPressure>0) adjust+=weights.W_tempo*5*entry.blockPressure;
+            if(entry.move?.to?.kind==='home' && entry.progress<=6) adjust+=weights.W_endfit*4;
+            if(exposureRelief>0 && entry.afterExposure<mySnapshot.exposure) adjust+=weights.W_risk*4*exposureRelief;
+            entry.score+=adjust;
+          });
+        }
+      };
+      tuneByDifficulty();
       if(difficulty==='normal' || difficulty==='hard'){
         scored.forEach(entry=>{
           const expectedLoss=entry.threat.prob*(entry.progress*0.6+(entry.captureCount>0?2:1)+(entry.safeValue<0.6?2:0));


### PR DESCRIPTION
## Summary
- capture richer per-player board statistics to support AI decision making
- tailor AI scoring adjustments for easy, normal, and hard to emphasize distinct behaviours
- document the updated difficulty behaviours in both English and Traditional Chinese within the README

## Testing
- not run (logic-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68f0c65b3f408321b37be37ce5dd2496