### PR TITLE
docs: add LICENSE and CHANGELOG for release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2026-04-13
+### Added
+- Added a project-wide MIT `LICENSE` file for release readiness.
+- Added this `CHANGELOG.md` to track notable project updates.
+- Added release checklist progress updates for completed license/changelog tasks.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Skybound Flight Chess contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PROJECT_FINISH_CHECKLIST.md
+++ b/PROJECT_FINISH_CHECKLIST.md
@@ -23,8 +23,8 @@ Use this checklist to drive the MVP to a release-ready version.
 - [ ] Add first-time tutorial/onboarding hints.
 
 ## 5) Release Operations
-- [ ] Add `LICENSE`.
-- [ ] Add `CHANGELOG.md`.
+- [x] Add `LICENSE`.
+- [x] Add `CHANGELOG.md`.
 - [ ] Configure CI checks (lint + tests + basic static checks).
 - [ ] Publish a playable deployment target (GitHub Pages / Netlify).
 


### PR DESCRIPTION
### Motivation
- Provide clear project licensing and an initial changelog to satisfy release readiness checklist and make the repository redistributable under a permissive license.

### Description
- Added an MIT `LICENSE`, created `CHANGELOG.md` with an initial `0.1.0` entry, and updated `PROJECT_FINISH_CHECKLIST.md` to mark the `LICENSE` and `CHANGELOG.md` items complete.

### Testing
- Ran `git diff --check HEAD~1..HEAD` and `git status --short`, and committed the changes with `git commit -m "docs: add release metadata files"`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5651f20483218d2f2a077c12043c)